### PR TITLE
Actor img

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# Version 5.22.4
+* Unlinked tokens now use the token img instead of the actor img
+
 # Version 5.22.3
 * Fixed a case where we would sometimes lose the skill ref
 

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -828,7 +828,7 @@ export class BrCommonCard {
 
         const useTokenImg = this.token && !this.token.document.actorLink;
         render_data.actorImg = useTokenImg ? this.token.document.texture.src : this.actor.img;
-        render_data.actorImgScale = useTokenImg ? this.token.document.texture.scaleX : 1;
+        render_data.actorImgScale = useTokenImg ? this.token.document.texture.scaleX ?? 1 : 1;
 
         // Benny image
         render_data.benny_image = game.settings.get("swade", "bennyImage3DFront") || "/systems/swade/assets/benny/benny-chip-front.png";

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -53,7 +53,7 @@ export class BrCommonCard {
         this.render_data = {}; // Old render data, to be removed
         this.update_list = {}; // List of properties pending to be updated
         this.resist_buttons = [];
-        this.trait_roll = new TraitRoll();
+        this.traitRoll = new TraitRoll();
         this.showPopout = true;
         this.manual_mods = {};
         this.applicable_effects = [];
@@ -132,7 +132,7 @@ export class BrCommonCard {
             macro_buttons: this.macro_buttons,
             id: this.id,
             target_ids: this.target_ids,
-            trait_roll: this.trait_roll,
+            traitRoll: this.traitRoll,
             resist_buttons: this.resist_buttons,
             damage: this.damage,
             showPopout: this.showPopout,
@@ -172,7 +172,7 @@ export class BrCommonCard {
         for (const field of FIELDS) {
             this[field] = data[field];
         }
-        this.trait_roll.load(data.trait_roll);
+        this.traitRoll.load(data.traitRoll);
         if (this.message) {
             this.render_data = this.message.getFlag(
                 "betterrolls-swade2",
@@ -826,6 +826,10 @@ export class BrCommonCard {
         render_data.actor = this.actor;
         render_data.result_master_only = SettingsUtils.getWorldSetting(BRSW2_CONFIG.WORLD_SETTING_KEYS.resultCard) === "master";
 
+        const useTokenImg = this.token && !this.token.document.actorLink;
+        render_data.actorImg = useTokenImg ? this.token.document.texture.src : this.actor.img;
+        render_data.actorImgScale = useTokenImg ? this.token.document.texture.scaleX : 1;
+
         // Benny image
         render_data.benny_image = game.settings.get("swade", "bennyImage3DFront") || "/systems/swade/assets/benny/benny-chip-front.png";
 
@@ -842,11 +846,11 @@ export class BrCommonCard {
     }
 
     get show_rerolls() {
-        if (game.settings.get("swade", "dumbLuck") || !this.trait_roll.current_roll) {
+        if (game.settings.get("swade", "dumbLuck") || !this.traitRoll.currentRoll) {
             return true;
         }
 
-        return this.trait_roll.current_roll && !this.trait_roll.current_roll.is_fumble;
+        return this.traitRoll.currentRoll && !this.traitRoll.currentRoll.isCritFail;
     }
 
     /**

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -145,8 +145,8 @@ export async function rollAttribute(brCard, expendBenny) {
     for (const action of brCard.getSelectedActions()) {
         process_common_actions(action.code, extraData, macros, brCard.actor);
     }
-    if (brCard.trait_roll.is_rolled) {
-        brCard.trait_roll.reroll_mode = expendBenny ? "benny" : "free";
+    if (brCard.traitRoll.is_rolled) {
+        brCard.traitRoll.reroll_mode = expendBenny ? "benny" : "free";
     }
     if (expendBenny) {
         await spendBenny(brCard.actor);

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -45,7 +45,7 @@ export function BRSWRoll() {
     this.modifiers = []; // Array of modifiers {name, value, extraClass, dice}
     this.dice = []; // Array with the dice {sides, results: [int], label, extraClass}
     // noinspection JSUnusedGlobalSymbols
-    this.is_fumble = false;
+    this.isCritFail = false;
 }
 
 /**
@@ -719,8 +719,8 @@ async function getNewRollOptions(
             brCard.item,
             extraData,
         );
-        brCard.trait_roll.tn = targetData.value;
-        brCard.trait_roll.tn_reason = targetData.reason;
+        brCard.traitRoll.tn = targetData.value;
+        brCard.traitRoll.tn_reason = targetData.reason;
         extraOptions.target_modifiers = targetData.modifiers;
     }
 
@@ -816,13 +816,13 @@ async function getNewRollOptions(
 async function get_reroll_options(brCard, extraData) {
     // Reroll, clear out old reroll mods so we don't double add
     // This doesn't use filter() because the array is referenced elsewhere
-    brCard.trait_roll.modifiers.splice(
+    brCard.traitRoll.modifiers.splice(
         0,
-        brCard.trait_roll.modifiers.length,
-        ...brCard.trait_roll.modifiers.filter((mod) => !mod.isReroll)
+        brCard.traitRoll.modifiers.length,
+        ...brCard.traitRoll.modifiers.filter((mod) => !mod.isReroll)
     );
     //Reroll any dice modifiers
-    const modifiers = brCard.trait_roll.modifiers;
+    const modifiers = brCard.traitRoll.modifiers;
     for (let i = 0; i < modifiers.length; ++i) {
         if (modifiers[i].dice) {
             modifiers[i] = new TraitModifier(modifiers[i].name, modifiers[i].dice.formula);
@@ -830,24 +830,24 @@ async function get_reroll_options(brCard, extraData) {
         }
     }
     // Modifiers from effects
-    if (brCard.trait_roll.reroll_mode === "benny") {
+    if (brCard.traitRoll.reroll_mode === "benny") {
         for (const mod of brCard.actor.system.stats.globalMods.bennyTrait) {
             const newModifier = new TraitModifier(mod.label, mod.value);
             newModifier.isReroll = true;
-            brCard.trait_roll.modifiers.push(newModifier);
+            brCard.traitRoll.modifiers.push(newModifier);
         }
     }
     // Modifiers from actions
     if (extraData.reroll_modifier &&
-        (!brCard.trait_roll.reroll_mode ||
-            brCard.trait_roll.reroll_mode === extraData.reroll_mode)) {
+        (!brCard.traitRoll.reroll_mode ||
+            brCard.traitRoll.reroll_mode === extraData.reroll_mode)) {
         const newModifier = new TraitModifier(
             extraData.reroll_modifier.name,
             extraData.reroll_modifier.value,
         );
         newModifier.isReroll = true;
         newModifier.evaluate();
-        brCard.trait_roll.modifiers.push(newModifier);
+        brCard.traitRoll.modifiers.push(newModifier);
     }
 }
 
@@ -958,11 +958,11 @@ export async function roll_trait(brCard, traitDie, traitName, extraData) {
     const { actor } = brCard;
     const roll_options = { modifiers: [], rof: undefined };
 
-    if (!brCard.trait_roll.is_rolled) {
+    if (!brCard.traitRoll.is_rolled) {
         await getNewRollOptions(brCard, extraData, traitDie, roll_options);
     } else {
-        roll_options.modifiers = brCard.trait_roll.modifiers;
-        roll_options.rof = brCard.trait_roll.rof;
+        roll_options.modifiers = brCard.traitRoll.modifiers;
+        roll_options.rof = brCard.traitRoll.rof;
         await get_reroll_options(brCard, extraData);
     }
 
@@ -979,9 +979,9 @@ export async function roll_trait(brCard, traitDie, traitName, extraData) {
 
     if ((actor.isWildcard || extraData.add_wild_die) && wild_die_formula) {
         rollString += wild_die_formula;
-        brCard.trait_roll.wild_die = true;
+        brCard.traitRoll.wild_die = true;
     } else {
-        brCard.trait_roll.wild_die = false;
+        brCard.traitRoll.wild_die = false;
     }
 
     if (extraData.total_aiming_ignorable_penalties > 0 && extraData.aiming_ignore_data?.length > 0) {
@@ -989,19 +989,19 @@ export async function roll_trait(brCard, traitDie, traitName, extraData) {
         apply_aiming_ignore(extraData);
     }
 
-    brCard.trait_roll.modifiers = roll_options.modifiers;
+    brCard.traitRoll.modifiers = roll_options.modifiers;
 
     if (extraData.tn) {
-        brCard.trait_roll.tn = extraData.tn;
-        brCard.trait_roll.tn_reason = extraData.tn_reason;
+        brCard.traitRoll.tn = extraData.tn;
+        brCard.traitRoll.tn_reason = extraData.tn_reason;
     }
 
-    brCard.trait_roll.arcaneActivationOffset = extraData.arcaneActivationOffset;
+    brCard.traitRoll.arcaneActivationOffset = extraData.arcaneActivationOffset;
 
     const roll = new Roll(rollString);
     await roll.evaluate();
-    await brCard.trait_roll.add_roll(roll);
-    await roll_dice(brCard.message, brCard.trait_roll, roll);
+    await brCard.traitRoll.add_roll(roll);
+    await roll_dice(brCard.message, brCard.traitRoll, roll);
 
     await brCard.render();
     await brCard.save();
@@ -1014,10 +1014,10 @@ export async function roll_trait(brCard, traitDie, traitName, extraData) {
  */
 async function old_roll_clicked(event, brCard) {
     let index = parseInt(event.currentTarget.dataset.index);
-    if (index >= brCard.trait_roll.selected_roll_index) {
+    if (index >= brCard.traitRoll.selected_roll_index) {
         index += 1;
     }
-    brCard.trait_roll.selected_roll_index = index;
+    brCard.traitRoll.selected_roll_index = index;
     if (
         brCard.item &&
         !isNaN(parseInt(brCard.item.system.pp)) &&
@@ -1043,11 +1043,11 @@ async function old_roll_clicked(event, brCard) {
  * @param {int, string} new_value
  */
 async function override_die_result(brCard, die_index, new_value) {
-    brCard.trait_roll.current_roll.dice[die_index].raw_total =
+    brCard.traitRoll.currentRoll.dice[die_index].raw_total =
         parseInt(new_value);
-    await brCard.trait_roll.recalculate_trait_results(
-        brCard.trait_roll.tn,
-        brCard.trait_roll.wild_die,
+    await brCard.traitRoll.recalculate_trait_results(
+        brCard.traitRoll.tn,
+        brCard.traitRoll.wild_die,
     );
     await brCard.render();
     await brCard.save();
@@ -1075,10 +1075,10 @@ async function add_modifier(brCard, modifier) {
         const newMod = new TraitModifier(name, modifier.value);
         await newMod.evaluate();
         if (newMod.dice) {
-            await roll_dice(brCard.message, brCard.trait_roll, newMod.dice);
+            await roll_dice(brCard.message, brCard.traitRoll, newMod.dice);
         }
-        brCard.trait_roll.modifiers.push(newMod);
-        await brCard.trait_roll.recalculate_trait_results();
+        brCard.traitRoll.modifiers.push(newMod);
+        await brCard.traitRoll.recalculate_trait_results();
         await brCard.render();
         brCard.save().catch(() => {
             console.error("Error saving a card after adding a modifier");
@@ -1092,8 +1092,8 @@ async function add_modifier(brCard, modifier) {
  * @param {int} index - Index of the modifier to delete.
  */
 async function delete_modifier(brCard, index) {
-    brCard.trait_roll.modifiers.splice(index, 1);
-    await brCard.trait_roll.recalculate_trait_results();
+    brCard.traitRoll.modifiers.splice(index, 1);
+    await brCard.traitRoll.recalculate_trait_results();
     await brCard.render();
     brCard.save().catch(() => {
         console.error("Error saving a card after deleting a modifier");
@@ -1111,9 +1111,9 @@ async function editModifier(brCard, index, newModifier) {
     // Add float modifier support
     const modValue = parseFloat(newModifier.value);
     if (Number.isFinite(modValue)) {
-        brCard.trait_roll.modifiers[index].name = newModifier.name;
-        brCard.trait_roll.modifiers[index].value = modValue;
-        await brCard.trait_roll.recalculate_trait_results();
+        brCard.traitRoll.modifiers[index].name = newModifier.name;
+        brCard.traitRoll.modifiers[index].value = modValue;
+        await brCard.traitRoll.recalculate_trait_results();
         await brCard.render();
         brCard.save();
     }
@@ -1127,11 +1127,11 @@ async function editModifier(brCard, index, newModifier) {
  * @param {string} reason - If it is set the reason will be changed
  */
 async function edit_tn(brCard, new_tn, reason) {
-    brCard.trait_roll.tn = new_tn;
+    brCard.traitRoll.tn = new_tn;
     if (reason) {
-        brCard.trait_roll.tn_reason = reason;
+        brCard.traitRoll.tn_reason = reason;
     }
-    await brCard.trait_roll.recalculate_trait_results();
+    await brCard.traitRoll.recalculate_trait_results();
     await brCard.render();
     brCard.save().catch(() => {
         console.error("Error saving a card after editing a TN");
@@ -1174,12 +1174,12 @@ async function getTNFromTarget(brCard, selected) {
             extraData,
         );
 
-        brCard.trait_roll.delete_range_modifiers();
-        brCard.trait_roll.modifiers = brCard.trait_roll.modifiers.concat(
+        brCard.traitRoll.delete_range_modifiers();
+        brCard.traitRoll.modifiers = brCard.traitRoll.modifiers.concat(
             tn.modifiers,
         );
 
-        await brCard.trait_roll.recalculate_trait_results();
+        await brCard.traitRoll.recalculate_trait_results();
         await brCard.render();
         await brCard.save();
     }
@@ -1212,7 +1212,7 @@ async function duplicate_message(message, event) {
     delete data._id;
     const new_message = await ChatMessage.create(data);
     const brCard = new BrCommonCard(new_message);
-    brCard.trait_roll = new TraitRoll();
+    brCard.traitRoll = new TraitRoll();
     brCard.render_data.damage_rolls = [];
     await brCard.render();
     await brCard.save();

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -293,7 +293,7 @@ async function rollSoak(brCard, useBenny) {
     );
 
     let result = 0;
-    for (const roll of brCard.trait_roll.rolls) {
+    for (const roll of brCard.traitRoll.rolls) {
         for (const die of roll.dice) {
             if (die.result !== null) {
                 result = Math.max(die.final_total, result);

--- a/scripts/incapacitation_card.js
+++ b/scripts/incapacitation_card.js
@@ -107,7 +107,7 @@ async function roll_incapacitation(brCard, spend_benny) {
         {},
     );
     let result = 0;
-    for (let roll of brCard.trait_roll.rolls) {
+    for (let roll of brCard.traitRoll.rolls) {
         for (let die of roll.dice) {
             if (die.result !== null) {
                 result = Math.max(die.final_total, result);
@@ -116,7 +116,7 @@ async function roll_incapacitation(brCard, spend_benny) {
     }
     brCard.render_data.show_roll_injury = true;
     brCard.render_data.injury_type = "none";
-    if (brCard.trait_roll.current_roll.is_fumble) {
+    if (brCard.traitRoll.currentRoll.isCritFail) {
         brCard.render_data.text_after = `</p><p>${game.i18n.localize(
             "BRSW.Fumble",
         )}</p><p>${brCard.token.name} ${game.i18n.localize("BRSW.IsDead")}</p>`;

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -616,8 +616,8 @@ async function roll_resist(trait, brCard, trait_mod) {
             newCard = await game.brsw.createSkillCard(token, Utils.traitFromString(token.actor, trait).id);
         }
 
-        newCard.trait_roll.tn = getTraitRollDifficulty(brCard);
-        newCard.trait_roll.tn_reason = game.i18n.localize("BRSW.ResistingRoll");
+        newCard.traitRoll.tn = getTraitRollDifficulty(brCard);
+        newCard.traitRoll.tn_reason = game.i18n.localize("BRSW.ResistingRoll");
         if (!isNaN(trait_mod)) {
             const localized_name = game.i18n.localize("BRSW.ResistingRoll");
             const resist_action = new brAction(localized_name, {
@@ -654,15 +654,15 @@ function getTraitRollDifficulty(brCard) {
         }
     }
 
-    if (!brCard.trait_roll.current_roll) {
-        return brCard.trait_roll.tn;
+    if (!brCard.traitRoll.currentRoll) {
+        return brCard.traitRoll.tn;
     }
 
-    const results = brCard.trait_roll.current_roll.dice.map((die) => {
+    const results = brCard.traitRoll.currentRoll.dice.map((die) => {
         return die.result;
     });
 
-    return Math.max(...results) + brCard.trait_roll.tn;
+    return Math.max(...results) + brCard.traitRoll.tn;
 }
 
 export async function displayPPChangeCard(actor, chatData) {
@@ -704,12 +704,12 @@ export async function spendPP(brCard, prevSpentPP) {
 
     let success = false;
     let raise = false;
-    for (const roll of brCard.trait_roll.current_roll.dice) {
+    for (const roll of brCard.traitRoll.currentRoll.dice) {
         if (roll.result === null) continue;
 
         //Subtract any arcaneActivationOffset from the roll result to get the activation roll
         //This is for cases like missing with bolt due to cover but the power still activates
-        const rollResult = roll.result - (brCard.trait_roll.arcaneActivationOffset ?? 0);
+        const rollResult = roll.result - (brCard.traitRoll.arcaneActivationOffset ?? 0);
         success = success || rollResult >= 0;
         raise = raise || rollResult >= 4;
     }
@@ -847,8 +847,8 @@ export async function rollItem(brCard, html, expendBennie, rollDamage) {
     const macros = [];
     let shotsOverride; // Override the number of shots used
     const extraData = { modifiers: [] };
-    if (brCard.trait_roll.is_rolled) {
-        brCard.trait_roll.reroll_mode = expendBennie ? "benny" : "free";
+    if (brCard.traitRoll.is_rolled) {
+        brCard.traitRoll.reroll_mode = expendBennie ? "benny" : "free";
     }
 
     if (expendBennie) {
@@ -980,8 +980,8 @@ export async function rollItem(brCard, html, expendBennie, rollDamage) {
             ? !!html.querySelector(".brsw-ammo-toggle.brsw-toggle-active")
             : SettingsUtils.getWorldSetting(WORLD_SETTING_KEYS.defaultAmmoManagement);
         if (consumeAmmoSelected || macros.length) {
-            brCard.render_data.used_shots = shotsOverride || ROF_BULLETS[brCard.trait_roll.rof || 1];
-            if (consumeAmmoSelected && brCard.trait_roll.rolls.length === 1) {
+            brCard.render_data.used_shots = shotsOverride || ROF_BULLETS[brCard.traitRoll.rof || 1];
+            if (consumeAmmoSelected && brCard.traitRoll.rolls.length === 1) {
                 await brCard.item.consume(brCard.render_data.used_shots);
             }
         }
@@ -989,7 +989,7 @@ export async function rollItem(brCard, html, expendBennie, rollDamage) {
 
     // Power points management
     const subtractPP = brCard.render_data.subtractPP;
-    const previous_pp = brCard.trait_roll.old_rolls.length ? brCard.render_data.used_pp : 0;
+    const previous_pp = brCard.traitRoll.old_rolls.length ? brCard.render_data.used_pp : 0;
     if (subtractPP && !isNaN(parseInt(brCard.item.system.pp)) && brCard.item.type === "power") {
         brCard.render_data.used_pp = await spendPP(brCard, previous_pp);
     }
@@ -1002,7 +1002,7 @@ export async function rollItem(brCard, html, expendBennie, rollDamage) {
     //Call a hook after roll for other modules
     Hooks.call("BRSW-RollItem", brCard, html);
     if (rollDamage && brCard.damage) {
-        brCard.trait_roll.current_roll.dice.forEach((roll) => {
+        brCard.traitRoll.currentRoll.dice.forEach((roll) => {
             if (roll.result !== null && roll.result >= 0) {
                 roll_dmg(brCard, html, false, {}, roll.result > 3);
             }

--- a/scripts/remove_status_cards.js
+++ b/scripts/remove_status_cards.js
@@ -140,7 +140,7 @@ async function roll_unshaken(brCard, use_bennie) {
       { modifiers: modifiers },
     );
     let result = 0;
-    for (let roll of brCard.trait_roll.rolls) {
+    for (let roll of brCard.traitRoll.rolls) {
       for (let die of roll.dice) {
         if (die.result !== null) {
           result = Math.max(die.final_total, result);
@@ -277,7 +277,7 @@ async function roll_unstun(brCard) {
     extra_options,
   );
   let result = 0;
-  for (let roll of brCard.trait_roll.rolls) {
+  for (let roll of brCard.traitRoll.rolls) {
     for (let die of roll.dice) {
       if (die.result !== null) {
         result = Math.max(die.final_total, result);

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -82,7 +82,7 @@ class Die {
 class SingleRoll {
   constructor(data) {
     this.dice = [];
-    this.is_fumble = false;
+    this.isCritFail = false;
     if (data) {
       this.load(data);
     }
@@ -127,7 +127,7 @@ class SingleRoll {
       this.dice[min_position].extraClass += " brsw-discarded-roll";
       this.dice[min_position].result = null;
     }
-    this.is_fumble = await detect_fumble(
+    this.isCritFail = await detect_fumble(
       has_wild_die,
       num_fumble_results,
       this.dice,
@@ -177,7 +177,7 @@ export class TraitRoll {
     this.selected_roll_index = this.rolls.indexOf(new_roll);
   }
 
-  get current_roll() {
+  get currentRoll() {
     if (this.rolls.length > 0) {
       return this.rolls[this.selected_roll_index];
     }
@@ -214,9 +214,9 @@ export class TraitRoll {
   }
 
   get rof() {
-    if (this.current_roll) {
+    if (this.currentRoll) {
       const wild_die = this.wild_die ? -1 : 0;
-      return this.current_roll.dice.length + wild_die;
+      return this.currentRoll.dice.length + wild_die;
     }
   }
 

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -175,8 +175,8 @@ export async function rollSkill(brCard, expendBennie) {
     for (const action of brCard.getSelectedActions()) {
         process_common_actions(action.code, extraData, macros, brCard.actor);
     }
-    if (brCard.trait_roll.is_rolled) {
-        brCard.trait_roll.reroll_mode = expendBennie ? "benny" : "free";
+    if (brCard.traitRoll.is_rolled) {
+        brCard.traitRoll.reroll_mode = expendBennie ? "benny" : "free";
     }
     if (expendBennie) {
         await spendBenny(brCard.actor);

--- a/scripts/vehicle_card.js
+++ b/scripts/vehicle_card.js
@@ -85,7 +85,7 @@ async function vehicle_weapon_clicked(ev, vehicle) {
                 await rollSkill(brCard, false);
 
                 if (brCard.damage && action.includes("damage")) {
-                    brCard.trait_roll.current_roll.dice.forEach((roll) => {
+                    brCard.traitRoll.currentRoll.dice.forEach((roll) => {
                         if (roll.result !== null && roll.result >= 0) {
                             roll_dmg(brCard, "", false, {}, roll.result > 3);
                         }

--- a/templates/card_dialog.hbs
+++ b/templates/card_dialog.hbs
@@ -50,7 +50,7 @@
         <button type="button" id="brsw-save-button" class="brsw-dialog-button">
             Set
         </button>
-        {{#unless BrCard.trait_roll.is_rolled}}
+        {{#unless BrCard.traitRoll.is_rolled}}
             <button type="button" id="brsw-dialog-roll" class="brsw-dialog-button">
                 <i class="fas fa-dice"></i> {{localize 'BRSW.Roll'}}
             </button>

--- a/templates/common_card_header.hbs
+++ b/templates/common_card_header.hbs
@@ -1,6 +1,6 @@
 <div id="brc-{{id}}" class="brsw-card-header-row">
-    <div>
-        <img class="brsw-actor-img" src="{{{actor.img}}}" alt="Actor portrait">
+    <div class="brsw-actor-img">
+        <img src="{{{actorImg}}}" alt="Actor portrait" style="transform: scale({{actorImgScale}});">
     </div>
     {{#if vehicleActor}}
         <div class="brsw-vehicle-img-wrapper">

--- a/templates/damage_card.hbs
+++ b/templates/damage_card.hbs
@@ -5,7 +5,7 @@
         <i class="fas fa-undo"></i>
     </button>
 </div>
-{{#if trait_roll.rolls}}
+{{#if traitRoll.rolls}}
     {{>"modules/betterrolls-swade2/templates/trait_roll_partial.hbs"}}
     {{>"modules/betterrolls-swade2/templates/trait_result_partial.hbs"}}
 {{else}}

--- a/templates/incapacitation_card.hbs
+++ b/templates/incapacitation_card.hbs
@@ -2,7 +2,7 @@
 <div class="brsw-card-row brsw-card-row-divider">
     {{{text}}}{{{text_after}}}
 </div>
-{{#if trait_roll.rolls}}
+{{#if traitRoll.rolls}}
     {{>"modules/betterrolls-swade2/templates/trait_roll_partial.hbs"}}
     {{>"modules/betterrolls-swade2/templates/trait_result_partial.hbs"}}
 {{else}}

--- a/templates/remove_status_card.hbs
+++ b/templates/remove_status_card.hbs
@@ -2,7 +2,7 @@
 <div class="brsw-card-row-divider">
   {{{text}}}
 </div>
-{{#if trait_roll.rolls}}
+{{#if traitRoll.rolls}}
   {{>"modules/betterrolls-swade2/templates/trait_roll_partial.hbs"}}
   {{>"modules/betterrolls-swade2/templates/trait_result_partial.hbs"}}
 {{else}}

--- a/templates/trait_result_partial.hbs
+++ b/templates/trait_result_partial.hbs
@@ -1,4 +1,4 @@
-{{#if trait_roll.current_roll.is_fumble}}
+{{#if traitRoll.currentRoll.isCritFail}}
     <div class="brsw-fumble-row">
         {{localize 'BRSW.Fumble'}}
     </div>
@@ -13,10 +13,10 @@
                 <i class="brsw-selected-tn brsw-clickable fas fa-object-ungroup brsw-form" data-index="-1" title="{{localize 'BRSW.TNSelected'}}"></i>
             </span>
         </div>
-        {{#each trait_roll.current_roll.dice}}
+        {{#each traitRoll.currentRoll.dice}}
             {{#if this.is_not_discarded}}
                 <div class="brsw-roll-detail-row brsw-editable-tn-row brsw-edit-tn" data-index="{{@index}}" data-value="{{this.tn}}" title='{{localize "BRSW.EditTN"}}'>
-                    <span title="{{localize ../trait_roll.tn_reason}}">{{localize "BRSW.TN"}} {{../trait_roll.tn}} {{localize "BRSW.Result"}} {{this.final_total}}</span>
+                    <span title="{{localize ../traitRoll.tn_reason}}">{{localize "BRSW.TN"}} {{../traitRoll.tn}} {{localize "BRSW.Result"}} {{this.final_total}}</span>
                     <span>
                         {{this.result_text}}
                         <i class="brsw-target-tn brsw-clickable fas fa-bullseye brsw-form" data-index="{{@index}}" title="{{localize 'BRSW.TNTargeted'}}"></i>

--- a/templates/trait_roll_partial.hbs
+++ b/templates/trait_roll_partial.hbs
@@ -1,9 +1,9 @@
-{{#if trait_roll.is_rolled}}
-    {{#if trait_roll.old_rolls}}
+{{#if traitRoll.is_rolled}}
+    {{#if traitRoll.old_rolls}}
         <div class="brsw-old-rolls">
             <span class="brsw-small-font">{{localize 'BRSW.OldRoll'}}</span>
             <div class="brsw-roll-row">
-                {{#each trait_roll.old_rolls}}
+                {{#each traitRoll.old_rolls}}
                     <span class="brsw-old-roll" data-index="{{@index}}">
                         {{#each dice}}
                             <span class="brsw-small-dice-image {{this.extraClass}}">
@@ -17,7 +17,7 @@
     <div class="brsw-roll-results-wrapper brsw-collapse-button" data-collapse="brsw-roll-detail">
         <div class="brsw-roll-results">
             <div class="brsw-roll-values">
-                {{#each trait_roll.current_roll.dice}}
+                {{#each traitRoll.currentRoll.dice}}
                     <div class="brsw-roll-value brsw-roll-value-total">
                         <span class="{{this.extraClass}}" title="{{this.result_text}}">
                             {{this.final_total}}
@@ -46,7 +46,7 @@
                 <i class="fas fa-plus-circle" title="{{localize 'BRSW.AddModifier'}}"></i>
             </span>
         </div>
-        {{#each trait_roll.current_roll.dice as |current_dice|}}
+        {{#each traitRoll.currentRoll.dice as |current_dice|}}
             <div class="brsw-roll-detail-row brsw-editable-tn-row {{this.extraClass}} brsw-override-die" data-die-index="{{@index}}">
                 <span>{{this.label}}</span>
                 <span class="brsw-die-results">
@@ -56,7 +56,7 @@
                 </span>
             </div>
         {{/each}}
-        {{#each trait_roll.modifiers}}
+        {{#each traitRoll.modifiers}}
             <div class="brsw-roll-detail-row brsw-editable-tn-row {{this.extraClass}} brsw-edit-modifier" data-index="{{@index}}" data-label="{{this.name}}" data-value="{{this.value}}">
                 <span>{{this.name}}</span>
                 <span>


### PR DESCRIPTION
## Summary by Sourcery

Use token images for unlinked actors in card headers and align trait roll data structures and templates with updated naming conventions.

Enhancements:
- Rename trait roll-related properties (e.g., trait_roll to traitRoll, current_roll to currentRoll, is_fumble to isCritFail) across scripts and templates for consistency with updated data models.
- Add actorImg and actorImgScale to card render data and update the common card header to display the appropriate actor or token image, including scaled unlinked token portraits.

Documentation:
- Document the new behavior for unlinked tokens using token images in the changelog.