### PR TITLE
Added an option to not create a chat message when creating a card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# Version 5.24.0
+* Added an option to not create a chat message when creating a card
+
 # Version 5.23.0
 * Reworked tooltips
 * Reworked the repeat roll logic so that it doesn't end up with stale roll data

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -58,6 +58,7 @@ export class BrCommonCard {
         this.manual_mods = {};
         this.applicable_effects = [];
         this.pp_modifiers = {};
+        this.createChatMessage = true;
         if (message) {
             const data = this.message.getFlag("betterrolls-swade2", "br_data");
             if (data) {
@@ -80,6 +81,7 @@ export class BrCommonCard {
     async save() {
         if (!this.message) {
             await this.render();
+            return;
         }
         const { update_list } = this;
         update_list.id = this.message.id;
@@ -927,7 +929,7 @@ export class BrCommonCard {
 
         if (this.message) {
             this.update_list.content = newContent;
-        } else {
+        } else if (this.createChatMessage) {
             await this.createFoundryMessage(newContent);
         }
     }

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -23,7 +23,7 @@ import { Utils, addEventListenerAll } from "./utils.js";
  *   and a boolean meaning if they need to set on or off
  * @return {Promise} A promise for the BrCommonCard object
  */
-async function createAttributeCard(origin, name, { actions_stored = {} } = {},) {
+async function createAttributeCard(origin, name, { actions_stored = {}, options = {} } = {},) {
     const actor = Utils.toActor(origin);
 
     const translatedName = game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS[name]);
@@ -36,6 +36,7 @@ async function createAttributeCard(origin, name, { actions_stored = {} } = {},) 
             trait: Utils.traitFromString(actor, translatedName),
         },
         "modules/betterrolls-swade2/templates/attribute_card.hbs",
+        options,
     );
 
     brCard.type = BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ATTRIBUTE_CARD;

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -61,7 +61,7 @@ function createAttributeCardFromId(
     token_id,
     actor_id,
     name,
-    { actions_stored = {} } = {},
+    { actions_stored = {}, options = {} } = {},
 ) {
     const actor = getActorFromIds(token_id, actor_id);
     return createAttributeCard(actor, name, {

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -64,6 +64,7 @@ export function exposeCardClass() {
  * @param {PlaceableObject|SwadeActor} origin - The origin of this card.
  * @param {Object} render_data - Data to pass to the render template.
  * @param {string} template - Path to the template that renders this card.
+ * @param {Object} options
  * @returns {BrCommonCard} The created common card.
  */
 export function create_common_card(origin, render_data, template, options) {

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -66,11 +66,15 @@ export function exposeCardClass() {
  * @param {string} template - Path to the template that renders this card.
  * @returns {BrCommonCard} The created common card.
  */
-export function create_common_card(origin, render_data, template) {
+export function create_common_card(origin, render_data, template, options) {
     const actor = Utils.toActor(origin);
 
     const brCard = new BrCommonCard(undefined);
     brCard.actor_id = actor.id;
+
+    if (options.createChatMessage != null) {
+        brCard.createChatMessage = options.createChatMessage;
+    }
 
     if (actor !== origin) {
         brCard.token_id = origin.id;

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -296,7 +296,7 @@ function createItemCardFromId(
     token_id,
     actor_id,
     itemId,
-    { actions_stored = {} } = {},
+    { actions_stored = {}, options = {} } = {},
 ) {
     let origin;
     if (canvas && token_id) {

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -54,7 +54,7 @@ const ROF_BULLETS = { 1: 1, 2: 5, 3: 10, 4: 20, 5: 40, 6: 50 };
 export async function createItemCard(
     origin,
     item_id,
-    { actions_stored = {}, vehicle } = {},
+    { actions_stored = {}, vehicle, options = {} } = {},
 ) {
     const actor = Utils.toActor(origin);
 
@@ -98,6 +98,7 @@ export async function createItemCard(
             swade_templates: get_template_from_item(item),
         },
         "modules/betterrolls-swade2/templates/item_card.hbs",
+        options,
     );
 
     brCard.type = BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ITEM_CARD;

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -34,7 +34,7 @@ import {
 async function createSkillCard(
     origin,
     skillId,
-    { actions_stored = {}, vehicle } = {},
+    { actions_stored = {}, vehicle, options = {} } = {},
 ) {
     const actor = Utils.toActor(origin);
     const skill = actor.items.get(skillId);
@@ -51,6 +51,7 @@ async function createSkillCard(
             description: skill.system.description,
         },
         "modules/betterrolls-swade2/templates/skill_card.hbs",
+        options,
     );
     brCard.type = BRSW2_CONST.BRSW_CARD_TYPES.TYPE_SKILL_CARD;
     if (vehicle) {

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -80,7 +80,7 @@ function createSkillCardFromId(
     tokenId,
     actorId,
     skillId,
-    { actions_stored = {} } = {},
+    { actions_stored = {}, options = {} } = {},
 ) {
     const actor = getActorFromIds(tokenId, actorId);
     return createSkillCard(actor, skillId, {


### PR DESCRIPTION
## Summary by Sourcery

Support creating cards without automatically posting them as chat messages.

New Features:
- Allow card creation APIs to suppress creation of a Foundry chat message through an option.

Enhancements:
- Avoid attempting to save a chat message after rendering a card without an existing message.