### PR TITLE
Shields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Version 5.27.0
 * Added an "Ignore Shield" attack action that cancels out the parry bonus granted by a target's shield
+* Ranged attacks against shield users now auto-select the matching cover action when possible
 
 # Version 5.26.0
 * We now combine effect and global actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# Version 5.27.0
+* Added an "Ignore Shield" attack action that cancels out the parry bonus granted by a target's shield
+
 # Version 5.26.0
 * We now combine effect and global actions
 * If an effect action comes from an edge or hindrance, it now gets put in the edge/hindrance group

--- a/docs/Global-Actions.md
+++ b/docs/Global-Actions.md
@@ -68,6 +68,7 @@ If this action is checked it will add a penalty of 4 to the skill roll and a bon
 * `overrideAp`: Override the Armor Penetration value of the item.
 * `multiplyDmgMod`: Multiply the final damage by this number.
 * `self_add_status`: Add that status to the token making the roll.
+* `ignoreShield`: If true, and the roll uses the target's parry as its TN, the shield parry bonus is removed.
 * `add_wild_die`: If true a wild die will be added to the roll even if it normally doesn't have one.
 * `avoid_exploding_damage`: If this is set to "true" damage will not explode (like when attacking objects)
 

--- a/docs/Global-Actions.md
+++ b/docs/Global-Actions.md
@@ -109,6 +109,7 @@ This group of fields are used to select when the action is available, you will n
 * `target_has_effect`: True if the target has an enabled Active Effect with the same name as the value.
 * `target_has_hindrance`: True if the target has a hindrance with the same name as the value.
 * `target_has_major_hindrance`: True if the target has a major hindrance with the same name as the value.
+* `target_shield_cover`: True if the cover modifier granted by the target's best readied shield matches `selector_value`. Supports equality operators (e.g. `<`, `>`, `!=`, etc.).
 * `target_value`: True if the value on the target matches the value in `selector_value`. `selector_value` must be composed of `"path=value"`, where path is a dot path of actor data (e.g. `system.advances.value`). Supports equality operators (e.g. `<`, `>`, `!=`, etc.).
 
 #### Complex Selectors

--- a/lang/en.json
+++ b/lang/en.json
@@ -163,6 +163,8 @@
   "BRSW.HideReRolls": "Hide reroll on Critical Failure",
   "BRSW.HideReRollsHint": "Check this to hide reroll options from the card on a Critical Failure",
   "BRSW.Hindrances": "Hindrances",
+  "BRSW.IgnoreShield": "Ignore Shield",
+  "BRSW.IgnoreShieldName": "Ignore Shield",
   "BRSW.Illumination": "Illumination",
   "BRSW.IlluminationDark": "Dark (-4)",
   "BRSW.IlluminationDim": "Dim (-2)",

--- a/scripts/actions/combat_options.js
+++ b/scripts/actions/combat_options.js
@@ -176,6 +176,16 @@ export const COMBAT_OPTIONS = [
         group: "BRSW.SituationalModifiers",
     },
     {
+        id: "IGNORESHIELD",
+        name: "BRSW.IgnoreShieldName",
+        button_name: "BRSW.IgnoreShield",
+        ignoreShield: true,
+        selector_type: "is_weapon_or_bolt",
+        selector_value: "true",
+        section: "attack",
+        group: "BRSW.SituationalModifiers",
+    },
+    {
         id: "AttackInanimateObject",
         name: "BRSW.AttackInanimate",
         button_name: "BRSW.AttackInanimate",

--- a/scripts/actions/combat_options.js
+++ b/scripts/actions/combat_options.js
@@ -114,6 +114,12 @@ export const COMBAT_OPTIONS = [
         group: "BRSW.Cover",
         group_single: true,
         aiming_ignores: true,
+        defaultChecked: {
+            and_selector: [
+                { selector_type: "is_ranged_attack", selector_value: "true" },
+                { selector_type: "target_shield_cover", selector_value: "-2" },
+            ],
+        },
     },
     {
         id: "2-MediumCover",
@@ -127,6 +133,12 @@ export const COMBAT_OPTIONS = [
         group: "BRSW.Cover",
         group_single: true,
         aiming_ignores: true,
+        defaultChecked: {
+            and_selector: [
+                { selector_type: "is_ranged_attack", selector_value: "true" },
+                { selector_type: "target_shield_cover", selector_value: "-4" },
+            ],
+        },
     },
     {
         id: "3-HeavyCover",
@@ -140,6 +152,12 @@ export const COMBAT_OPTIONS = [
         group: "BRSW.Cover",
         group_single: true,
         aiming_ignores: true,
+        defaultChecked: {
+            and_selector: [
+                { selector_type: "is_ranged_attack", selector_value: "true" },
+                { selector_type: "target_shield_cover", selector_value: "-6" },
+            ],
+        },
     },
     {
         id: "4-NearTotalCover",
@@ -153,6 +171,12 @@ export const COMBAT_OPTIONS = [
         group: "BRSW.Cover",
         group_single: true,
         aiming_ignores: true,
+        defaultChecked: {
+            and_selector: [
+                { selector_type: "is_ranged_attack", selector_value: "true" },
+                { selector_type: "target_shield_cover", selector_value: "-8" },
+            ],
+        },
     },
     {
         id: "TOUCHATTACK",

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -1161,6 +1161,7 @@ async function getTNFromTarget(brCard, selected) {
     const targetToken = selected ? getSelectedToken([brCard.actor]) : getTargetedToken([brCard.actor]);
     if (targetToken) {
         const extraData = { modifiers: [] };
+        extraData.ignoreShield = brCard.getSelectedActions().some((action) => action.code.ignoreShield);
         const originToken = brCard.token;
         const target = await getTNFromToken(
             brCard.skill,
@@ -1299,6 +1300,9 @@ export function process_common_actions(action, extraData, macros, actor) {
     }
     if (action.dice) {
         extraData.rof = action.dice;
+    }
+    if (action.ignoreShield) {
+        extraData.ignoreShield = true;
     }
     if (action.tnOverride) {
         const userTargets = getUserTargets();

--- a/scripts/global_actions.js
+++ b/scripts/global_actions.js
@@ -441,6 +441,17 @@ function check_selector(type, value, item, actor, userTargets) {
         if (targeted_token) {
             selected = check_document_value(targeted_token.actor, value);
         }
+    } else if (type === "target_shield_cover") {
+        // The best cover modifier of target's equipped shields
+        const targetToken = userTargets[0];
+        const shields = targetToken?.actor?.itemTypes?.shield ?? [];
+        const bestCover = shields.reduce((best, shield) => {
+            if (Number(shield.system.equipStatus) <= 1) return best;
+            return Math.min(Number(shield.system.cover) || 0, best);
+        }, 0);
+        if (bestCover < 0) {
+            selected = Utils.check_equality_with_operators(bestCover, value);
+        }
     } else if (type === "item_has_damage") {
         selected = !!item?.system && (!!item.system.damage || check_for_actions_with_damage(item));
         if (value === "false") {

--- a/scripts/global_actions.js
+++ b/scripts/global_actions.js
@@ -275,7 +275,6 @@ function check_selector(type, value, item, actor, userTargets) {
         const description = `${item?.system?.description} ${item?.system?.trapping} ${item?.system?.category} ${item?.system?.notes}`;
         selected = description.toLowerCase().includes(value.toLowerCase());
     } else if (type === "actor_has_effect") {
-        // noinspection AnonymousFunctionJS
         const effect = actor.appliedEffects.find((effect) =>
             effect.name
                 .toLowerCase()
@@ -284,7 +283,6 @@ function check_selector(type, value, item, actor, userTargets) {
         selected = effect ? !effect.disabled : false;
     } else if (type === "actor_has_edge") {
         const edge_name = game.i18n.localize(value);
-        // noinspection AnonymousFunctionJS
         const edge = actor.items.find((item) => {
             return (
                 item.type === "edge" &&
@@ -294,7 +292,6 @@ function check_selector(type, value, item, actor, userTargets) {
         selected = !!edge;
     } else if (type === "actor_has_ability") {
         const ability_name = game.i18n.localize(value);
-        // noinspection AnonymousFunctionJS
         const ability = actor.items.find((item) => {
             return (
                 item.type === "ability" &&
@@ -304,7 +301,6 @@ function check_selector(type, value, item, actor, userTargets) {
         selected = !!ability;
     } else if (type === "actor_has_hindrance") {
         const hindrance_name = game.i18n.localize(value);
-        // noinspection AnonymousFunctionJS
         const hindrance = actor.items.find((item) => {
             return (
                 item.type === "hindrance" &&
@@ -314,7 +310,6 @@ function check_selector(type, value, item, actor, userTargets) {
         selected = !!hindrance;
     } else if (type === "actor_has_major_hindrance") {
         const hindrance_name = game.i18n.localize(value);
-        // noinspection AnonymousFunctionJS
         const hindrance = actor.items.find((item) => {
             return (
                 item.type === "hindrance" &&
@@ -335,9 +330,9 @@ function check_selector(type, value, item, actor, userTargets) {
         }
     } else if (type.indexOf("target_additional_stat_") === 0) {
         const additional_stat = type.slice(23);
-        for (const targeted_token of userTargets) {
-            if (targeted_token?.actor?.system?.additionalStats.hasOwnProperty(additional_stat)) {
-                if (Utils.check_equality_with_operators(targeted_token.actor.system.additionalStats[additional_stat].value, value)) {
+        for (const targetToken of userTargets) {
+            if (targetToken?.actor?.system?.additionalStats.hasOwnProperty(additional_stat)) {
+                if (Utils.check_equality_with_operators(targetToken.actor.system.additionalStats[additional_stat].value, value)) {
                     selected = true;
                     break;
                 }
@@ -346,12 +341,12 @@ function check_selector(type, value, item, actor, userTargets) {
     } else if (type === "actor_has_joker") {
         selected = actor.hasJoker;
     } else if (type === "target_has_edge") {
-        const edge_name = game.i18n.localize(value);
-        for (const targeted_token of userTargets) {
-            const edge = targeted_token.actor?.items.find((item) => {
+        const edgeName = game.i18n.localize(value);
+        for (const targetToken of userTargets) {
+            const edge = targetToken.actor?.items.find((item) => {
                 return (
                     item.type === "edge" &&
-                    item.name.toLowerCase().includes(edge_name.toLowerCase())
+                    item.name.toLowerCase().includes(edgeName.toLowerCase())
                 );
             });
             selected = selected || !!edge;
@@ -361,8 +356,8 @@ function check_selector(type, value, item, actor, userTargets) {
         selected = hasMastery == value;
     } else if (type === "target_has_hindrance") {
         const hindrance_name = game.i18n.localize(value);
-        for (const targeted_token of userTargets) {
-            const hindrance = targeted_token.actor?.items.find((item) => {
+        for (const targetToken of userTargets) {
+            const hindrance = targetToken.actor?.items.find((item) => {
                 return (
                     item.type === "hindrance" &&
                     item.name.toLowerCase().includes(hindrance_name.toLowerCase())
@@ -372,9 +367,8 @@ function check_selector(type, value, item, actor, userTargets) {
         }
     } else if (type === "target_has_major_hindrance") {
         const hindrance_name = game.i18n.localize(value);
-        // noinspection AnonymousFunctionJS
-        for (const targeted_token of userTargets) {
-            const hindrance = targeted_token.actor?.items.find((item) => {
+        for (const targetToken of userTargets) {
+            const hindrance = targetToken.actor?.items.find((item) => {
                 return (
                     item.type === "hindrance" &&
                     item.name.toLowerCase().includes(hindrance_name.toLowerCase()) &&
@@ -399,11 +393,24 @@ function check_selector(type, value, item, actor, userTargets) {
         const abilityName = game.i18n.localize(value);
         for (const targeted_token of userTargets) {
             const effect = targeted_token.actor?.appliedEffects.find(
-                (ef) => ef.name.toLowerCase().includes(abilityName.toLowerCase()), // jshint ignore:line
+                (ef) => ef.name.toLowerCase().includes(abilityName.toLowerCase()),
             );
             if (effect) {
                 selected = selected || effect ? !effect.disabled : false;
             }
+        }
+    } else if (type === "target_shield_cover") {
+        // The best cover modifier among all the targets' equipped shields
+        let bestCover = 0;
+        for (const targetToken of userTargets) {
+            const shields = targetToken?.actor?.itemTypes?.shield ?? [];
+            bestCover = shields.reduce((best, shield) => {
+                if (Number(shield.system.equipStatus) <= 1) return best;
+                return Math.min(Number(shield.system.cover) || 0, best);
+            }, bestCover);
+        }
+        if (bestCover < 0) {
+            selected = Utils.check_equality_with_operators(bestCover, value);
         }
     } else if (type === "gm_action_enabled") {
         const gm_actions = get_enabled_gm_actions();
@@ -440,17 +447,6 @@ function check_selector(type, value, item, actor, userTargets) {
         const targeted_token = userTargets[0];
         if (targeted_token) {
             selected = check_document_value(targeted_token.actor, value);
-        }
-    } else if (type === "target_shield_cover") {
-        // The best cover modifier of target's equipped shields
-        const targetToken = userTargets[0];
-        const shields = targetToken?.actor?.itemTypes?.shield ?? [];
-        const bestCover = shields.reduce((best, shield) => {
-            if (Number(shield.system.equipStatus) <= 1) return best;
-            return Math.min(Number(shield.system.cover) || 0, best);
-        }, 0);
-        if (bestCover < 0) {
-            selected = Utils.check_equality_with_operators(bestCover, value);
         }
     } else if (type === "item_has_damage") {
         selected = !!item?.system && (!!item.system.damage || check_for_actions_with_damage(item));

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -382,6 +382,13 @@ export async function getTNFromToken(
         if (targetActor.type !== "vehicle") {
             tn.reason = `${game.i18n.localize("SWADE.Parry")} - ${targetToken.name}`;
             tn.value = parseInt(targetActor.system.stats.parry.value);
+            if (extraData?.ignoreShield) {
+                const shield = parseInt(targetActor.system.stats.parry.shield);
+                if (shield) {
+                    tn.value -= shield;
+                    tn.reason = `${game.i18n.localize("BRSW.IgnoreShield")} - ${targetToken.name}`;
+                }
+            }
         } else {
             await get_vehicle_tn(tn, targetToken);
         }


### PR DESCRIPTION
## Summary by Sourcery

Improve shield interactions by supporting attacks that bypass shield parry bonuses and automatically account for shield-provided cover.

New Features:
- Add an Ignore Shield attack action that removes a target shield’s parry bonus from attack target numbers.
- Automatically select matching cover actions for ranged attacks against targets using shields.

Enhancements:
- Extend global action selectors to support matching equipped shield cover modifiers.
- Document the new shield-related action and selector options.