### PR TITLE
Damage types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# Version 5.28.0
+* Added item_damage_has_type, target_has_damage_resistance, and target_has_damage_weakness selectors
+
 # Version 5.27.1
 * We now update the message after every damage roll when rolling for multiple targets
 

--- a/docs/Global-Actions.md
+++ b/docs/Global-Actions.md
@@ -97,6 +97,7 @@ This group of fields are used to select when the action is available, you will n
 * `is_weapon_or_bolt`: True if the item is either a weapon or the bolt power.
 * `is_wildcard`: True if the actor is a Wildcard.
 * `item_additional_stat_xxx`: True if the item has an additional stat named xxx and its value matches the comparison. Supports equality operators (e.g. `<`, `>`, `!=`, etc.).
+* `item_damage_has_type`: True if the item's damage formula has a damage type flag matching the value (e.g. `[fire]` in `2d6[fire]`).
 * `item_description_includes`: True if the item's description, trappings, category, and/or notes includes the value.
 * `item_has_damage`: True if the item or one of its actions has a damage value.
 * `item_name`: True if the item includes the value in its name.
@@ -105,6 +106,8 @@ This group of fields are used to select when the action is available, you will n
 * `module_is_not_active`: True when the module with that identifier is not active. It is mainly to avoid automation duplication with other modules like the Core Rules.
 * `range_less_than`: True when the range between the actor's token and the targeted token is less or equal than value.
 * `skill`: True when the card uses a skill with that name.
+* `target_has_damage_resistance`: True if the target has an Environmental Resistance ability whose damage types overlap with the item's damage types. The ability must be formatted like `Environmental Resistance (Cold, Fire)` or `Environmental Resistance (Bludgeoning and enchanted weapons)`.
+* `target_has_damage_weakness`: True if the target has an Environmental Weakness ability whose damage types overlap with the item's damage types. The ability must be formatted like `Environmental Weakness (Cold, Fire)` or `Environmental Weakness (Bludgeoning and enchanted weapons)`.
 * `target_has_edge`: True if the target has an edge with the same name as the value.
 * `target_has_effect`: True if the target has an enabled Active Effect with the same name as the value.
 * `target_has_hindrance`: True if the target has a hindrance with the same name as the value.

--- a/lang/en.json
+++ b/lang/en.json
@@ -5,6 +5,8 @@
   "BRSW.AbilityName.Darkvision": "Darkvision",
   "BRSW.AbilityName.DarkVision": "Dark Vision",
   "BRSW.AbilityName.DemonHellfrost": "Demon",
+  "BRSW.AbilityName.EnvironmentalResistance": "Environmental Resistance",
+  "BRSW.AbilityName.EnvironmentalWeakness": "Environmental Weakness",
   "BRSW.AbilityName.LowLightVision": "Low Light Vision",
   "BRSW.AbilityName.NightVision": "Night Vision",
   "BRSW.AbilityName.Undead": "Undead",

--- a/scripts/global_actions.js
+++ b/scripts/global_actions.js
@@ -172,8 +172,8 @@ function actorHasMatchingDamageTypeAbility(abilityLocKey, item, actor, targets) 
     const itemDamageTypes = [...itemDamage.matchAll(/\[([^\]]+)\]/g)].map(
         (match) => match[1].toLowerCase(),
     );
-    for (const targeted_token of targets) {
-        const abilities = actor.items.filter((abilityItem) => {
+    for (const targetedToken of targets) {
+        const abilities = targetedToken.actor.items.filter((abilityItem) => {
             return abilityItem.type === "ability" && abilityItem.name.toLowerCase().includes(abilityName);
         });
         for (const ability of abilities) {

--- a/scripts/global_actions.js
+++ b/scripts/global_actions.js
@@ -158,6 +158,41 @@ export function get_actions(item, actor, userTargets) {
     return availableActions;
 }
 
+/**
+ * Checks if any target has an ability (e.g. environmental weakness/resistance) whose damage types match the item's damage types.
+ * @param abilityLocKey Localization key for the ability name
+ * @param item
+ * @param actor
+ * @param targets
+ * @return {boolean}
+ */
+function actorHasMatchingDamageTypeAbility(abilityLocKey, item, actor, targets) {
+    const abilityName = game.i18n.localize(abilityLocKey).toLowerCase();
+    const itemDamage = item.system.damage || "";
+    const itemDamageTypes = [...itemDamage.matchAll(/\[([^\]]+)\]/g)].map(
+        (match) => match[1].toLowerCase(),
+    );
+    for (const targeted_token of targets) {
+        const abilities = actor.items.filter((abilityItem) => {
+            return abilityItem.type === "ability" && abilityItem.name.toLowerCase().includes(abilityName);
+        });
+        for (const ability of abilities) {
+            const parenMatch = ability.name.match(/\(([^)]+)\)/);
+            if (parenMatch) {
+                const damageTypes = parenMatch[1]
+                    .split(/,|\band\b/i)
+                    .map((damageType) => damageType.replace(/\bweapons\b/i, "").trim().toLowerCase())
+                    .filter((damageType) => damageType);
+
+                if (itemDamageTypes.some((damageType) => damageTypes.includes(damageType))) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 // noinspection OverlyComplexFunctionJS,FunctionTooLongJS
 /**
  * Check if a selector matches
@@ -399,6 +434,20 @@ function check_selector(type, value, item, actor, userTargets) {
                 selected = selected || effect ? !effect.disabled : false;
             }
         }
+    } else if (type === "target_has_damage_weakness") {
+        selected = actorHasMatchingDamageTypeAbility(
+            "BRSW.AbilityName.EnvironmentalWeakness", item, actor, userTargets,
+        );
+        if (value === "false") {
+            selected = !selected;
+        }
+    } else if (type === "target_has_damage_resistance") {
+        selected = actorHasMatchingDamageTypeAbility(
+            "BRSW.AbilityName.EnvironmentalResistance", item, actor, userTargets,
+        );
+        if (value === "false") {
+            selected = !selected;
+        }
     } else if (type === "target_shield_cover") {
         // The best cover modifier among all the targets' equipped shields
         let bestCover = 0;
@@ -453,6 +502,12 @@ function check_selector(type, value, item, actor, userTargets) {
         if (value === "false") {
             selected = !selected;
         }
+    } else if (type === "item_damage_has_type") {
+        const itemDamage = item.system.damage || "";
+        const itemDamageTypes = [...itemDamage.matchAll(/\[([^\]]+)\]/g)].map(
+            (match) => match[1].toLowerCase(),
+        );
+        selected = itemDamageTypes.includes(value);
     } else if (type === "is_ranged_attack") {
         selected = Utils.isRangedAttack(item, actor);
         if (value === "false") {

--- a/scripts/global_actions.js
+++ b/scripts/global_actions.js
@@ -172,8 +172,8 @@ function actorHasMatchingDamageTypeAbility(abilityLocKey, item, actor, targets) 
     const itemDamageTypes = [...itemDamage.matchAll(/\[([^\]]+)\]/g)].map(
         (match) => match[1].toLowerCase(),
     );
-    for (const targetedToken of targets) {
-        const abilities = targetedToken.actor.items.filter((abilityItem) => {
+    for (const targetToken of targets) {
+        const abilities = targetToken.actor.items.filter((abilityItem) => {
             return abilityItem.type === "ability" && abilityItem.name.toLowerCase().includes(abilityName);
         });
         for (const ability of abilities) {

--- a/scripts/global_actions.js
+++ b/scripts/global_actions.js
@@ -507,7 +507,7 @@ function check_selector(type, value, item, actor, userTargets) {
         const itemDamageTypes = [...itemDamage.matchAll(/\[([^\]]+)\]/g)].map(
             (match) => match[1].toLowerCase(),
         );
-        selected = itemDamageTypes.includes(value);
+        selected = itemDamageTypes.includes(value.toLowerCase());
     } else if (type === "is_ranged_attack") {
         selected = Utils.isRangedAttack(item, actor);
         if (value === "false") {


### PR DESCRIPTION
## Summary by Sourcery

Add damage-type-aware selectors for item and target-based global action conditions.

New Features:
- Add selectors for matching item damage types and detecting target damage resistances or weaknesses.

Documentation:
- Document the new damage-type selectors and their supported ability formats.

Chores:
- Record the new selectors in the changelog and localization resources.